### PR TITLE
Fix URL in index to point to the correct repo

### DIFF
--- a/src/main/twirl/index.scala.html
+++ b/src/main/twirl/index.scala.html
@@ -4,7 +4,7 @@
 <head>
 <title>Lightning Timer</title>
 <!-- By Simon Willison - http://simonwillison.net/2008/Nov/12/lightning/ -->
-<!-- Modifications by Michael Brunton-Spall, http://github.com/bruntonspall/lightningtimer -->
+<!-- Modifications by Michael Brunton-Spall, http://github.com/bruntonspall/lightningtimer.net -->
 <script type="text/javascript">
 // Default settings: 5 minutes, warning at 1 minute
 var count = 5 * 60;


### PR DESCRIPTION
When looking at the source code of http://lightningtimer.appspot.com/ and wanting to find out more about the project, you cannot find it because there is a typo in the URL to the repo. This fixes that and points to the correct URL.